### PR TITLE
fix: ignore repetitions for groups with empty string literals

### DIFF
--- a/rulex-lib/src/repetition.rs
+++ b/rulex-lib/src/repetition.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 use crate::{
     compile::{CompileResult, CompileState},
@@ -174,6 +174,10 @@ impl<'i> RegexRepetition<'i> {
 
     pub(crate) fn codegen(&self, buf: &mut String, flavor: RegexFlavor) {
         use std::fmt::Write;
+
+        if let Regex::Literal(Cow::Borrowed("")) = self.content {
+            return;
+        }
 
         if self.content.needs_parens_before_repetition() {
             buf.push_str("(?:");

--- a/rulex-lib/tests/testcases/repetitions/13.txt
+++ b/rulex-lib/tests/testcases/repetitions/13.txt
@@ -1,0 +1,5 @@
+# repetitions for groups with empty string literals should be ignored
+
+:('test') ()?
+-----
+(test)


### PR DESCRIPTION
<!--
    The title should start with one of the following:
        feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
    For example: "feat: Frobnicate syntax"
-->

# Description

Fixes #24 

# Checklist:

- [x] My code is formatted with `cargo fmt`
- [x] My code compiles with the latest stable Rust toolchain
- [x] All tests pass with `cargo test`
- [x] My changes generate no new warnings with `cargo clippy`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes are covered by tests
